### PR TITLE
new: Partially support Volta's pinned versions

### DIFF
--- a/crates/common/src/package_json.rs
+++ b/crates/common/src/package_json.rs
@@ -9,6 +9,14 @@ pub enum BinField {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct VoltaField {
+    pub node: Option<String>,
+    pub npm: Option<String>,
+    pub pnpm: Option<String>,
+    pub yarn: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct PackageJson {
     pub bin: Option<BinField>,
 
@@ -22,4 +30,6 @@ pub struct PackageJson {
     pub package_manager: Option<String>,
 
     pub version: Option<String>,
+
+    pub volta: Option<VoltaField>,
 }

--- a/crates/node-depman/src/proto.rs
+++ b/crates/node-depman/src/proto.rs
@@ -76,6 +76,19 @@ pub fn parse_version_file(
                     }
                 }
             }
+
+            if version.is_none() {
+                if let Some(volta) = package_json.volta {
+                    if let Some(volta_tool_version) = match manager_name.as_str() {
+                        "npm" => volta.npm,
+                        "pnpm" => volta.pnpm,
+                        "yarn" => volta.yarn,
+                        _ => None,
+                    } {
+                        version = Some(UnresolvedVersionSpec::parse(volta_tool_version)?);
+                    }
+                }
+            }
         }
     }
 

--- a/crates/node-depman/tests/versions_test.rs
+++ b/crates/node-depman/tests/versions_test.rs
@@ -87,6 +87,22 @@ mod npm {
             }
         );
     }
+
+    #[test]
+    fn parses_volta() {
+        let sandbox = create_empty_sandbox();
+        let plugin = create_plugin("npm-test", sandbox.path());
+
+        assert_eq!(
+            plugin.parse_version_file(ParseVersionFileInput {
+                content: r#"{ "volta": { "npm": "1.2.3" } }"#.into(),
+                file: "package.json".into(),
+            }),
+            ParseVersionFileOutput {
+                version: Some(UnresolvedVersionSpec::parse("1.2.3").unwrap()),
+            }
+        );
+    }
 }
 
 mod pnpm {
@@ -152,6 +168,22 @@ mod pnpm {
         assert_eq!(
             plugin.parse_version_file(ParseVersionFileInput {
                 content: r#"{ "engines": { "pnpm": "1.2.3" } }"#.into(),
+                file: "package.json".into(),
+            }),
+            ParseVersionFileOutput {
+                version: Some(UnresolvedVersionSpec::parse("1.2.3").unwrap()),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_volta() {
+        let sandbox = create_empty_sandbox();
+        let plugin = create_plugin("pnpm-test", sandbox.path());
+
+        assert_eq!(
+            plugin.parse_version_file(ParseVersionFileInput {
+                content: r#"{ "volta": { "pnpm": "1.2.3" } }"#.into(),
                 file: "package.json".into(),
             }),
             ParseVersionFileOutput {
@@ -225,6 +257,22 @@ mod yarn {
         assert_eq!(
             plugin.parse_version_file(ParseVersionFileInput {
                 content: r#"{ "engines": { "yarn": "1.2.3" } }"#.into(),
+                file: "package.json".into(),
+            }),
+            ParseVersionFileOutput {
+                version: Some(UnresolvedVersionSpec::parse("1.2.3").unwrap()),
+            }
+        );
+    }
+
+    #[test]
+    fn parses_volta() {
+        let sandbox = create_empty_sandbox();
+        let plugin = create_plugin("yarn-test", sandbox.path());
+
+        assert_eq!(
+            plugin.parse_version_file(ParseVersionFileInput {
+                content: r#"{ "volta": { "yarn": "1.2.3" } }"#.into(),
                 file: "package.json".into(),
             }),
             ParseVersionFileOutput {

--- a/crates/node/src/proto.rs
+++ b/crates/node/src/proto.rs
@@ -48,6 +48,14 @@ pub fn parse_version_file(
                     version = Some(UnresolvedVersionSpec::parse(constraint)?);
                 }
             }
+
+            if version.is_none() {
+                if let Some(volta) = package_json.volta {
+                    if let Some(volta_node_version) = volta.node {
+                        version = Some(UnresolvedVersionSpec::parse(volta_node_version)?);
+                    }
+                }
+            }
         }
     } else {
         version = Some(UnresolvedVersionSpec::parse(input.content)?);

--- a/crates/node/tests/versions_test.rs
+++ b/crates/node/tests/versions_test.rs
@@ -65,3 +65,19 @@ fn parses_engines() {
         }
     );
 }
+
+#[test]
+fn parses_volta() {
+    let sandbox = create_empty_sandbox();
+    let plugin = create_plugin("node-test", sandbox.path());
+
+    assert_eq!(
+        plugin.parse_version_file(ParseVersionFileInput {
+            content: r#"{ "volta": { "node": "16.20.2" } }"#.into(),
+            file: "package.json".into(),
+        }),
+        ParseVersionFileOutput {
+            version: Some(UnresolvedVersionSpec::parse("16.20.2").unwrap()),
+        }
+    );
+}


### PR DESCRIPTION
To make migration from Volta easier, or simply to support when the choice of tool manager is out of your hands, this PR let's Proto use the tool versions pinned by Volta. Proto will still prefer the more official "engines" or "packageManager" if they're defined.

The `extends` field is not supported, but the implementation should cover the most common use-cases at least.

Some unrelated tests are failing on Windows, but I see they've been doing that for a while.